### PR TITLE
Allow numbers in the named and add missing installer types.

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -65,7 +65,7 @@ class AddInstallerFormFields(FlaskForm):
             RequiredIfFile('file')
         ])
     
-    installer_type = SelectField('Type', choices=[('exe', 'exe'), ('msi', 'msi'), ('msix', 'msix'), ('appx', 'appx'), ('zip', 'zip')], validators=[
+    installer_type = SelectField('Type', choices=[('exe', 'exe'), ('msi', 'msi'), ('msix', 'msix'), ('appx', 'appx'), ('zip', 'zip'), ('inno', 'inno'), ('nullsoft', 'nullsoft'), ('wix', 'wix'), ('burn', 'burn'), ('pwa', 'pwa'), ('msstore', 'msstore')], validators=[
             RequiredIfFile('file')
         ])
     

--- a/app/templates/modals/add_package.j2
+++ b/app/templates/modals/add_package.j2
@@ -64,8 +64,8 @@
                         <label for="identifier" class="block  text-gray-700 dark:text-gray-300 ">Identifier<span
                                 class="text-red-500">*</span></label>
                         <input required name="identifier" placeholder="" type="text" x-model="identifier"
-                            x-bind:value="identifierEditedManually ? identifier : (publisher.replace(/\s/g, '').replace(/[^a-zA-Z.äöüÄÖÜ]/g, '') + '.' + name.replace(/\s/g, '').replace(/[^a-zA-Z.äöüÄÖÜ]/g, ''))"
-                            @input="identifierEditedManually = true; identifier = identifier.replace(/\s/g, '').replace(/[^a-zA-Z.äöüÄÖÜ]/g, '')"
+                            x-bind:value="identifierEditedManually ? identifier : (publisher.replace(/\s/g, '').replace(/[^a-zA-Z0-9]/g, '') + '.' + name.replace(/\s/g, '').replace(/[^a-zA-Z0-9]/g, ''))"
+                            @input="identifierEditedManually = true; identifier = identifier.replace(/\s/g, '').replace(/[^a-zA-Z0-9]/g, '')"
                             class="block w-full px-3 py-2 mt-1 text-gray-600 dark:text-gray-200 placeholder-gray-400 bg-white dark:bg-neutral-950 border border-gray-200 dark:border-gray-50/30 rounded-md focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40">
                     </div>
 


### PR DESCRIPTION
Adding packaches with numbers in the name was not possible. For example 7zip.zip & 3Dconnexion.3DxWare.
I made a small change in the add_package file to make this work. I also removed the characters that are not used that often to make sure that they cannot give any problems.

Another problem was uploading exe files with the installer type inno or nullsoft. They were missing in form.py so I have added them. This now works.