### PR TITLE
Resolve file path issues when Publisher name contains spaces

### DIFF
--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -32,7 +32,7 @@ def add_package():
         return str("Form validation error"), 500
     
     name = form.name.data
-    publisher = form.publisher.data
+    publisher = secure_filename(form.publisher.data)
     identifier = form.identifier.data
     version = installer_form.version.data
     file = installer_form.file.data


### PR DESCRIPTION
When a publisher name is entered in the UI with spaces, the file name generated by the save_file function replaces them with underscores, however the database save function was not. This resulted in the download/delete/edit functions failing with a 404 error. 

Normalizing the publisher name with secure_filename prior to use in all further processing resolves this